### PR TITLE
Add BooleanField default value

### DIFF
--- a/flatpages_i18n/models.py
+++ b/flatpages_i18n/models.py
@@ -21,7 +21,7 @@ class FlatPage_i18n(MPTTModel):
         help_text=_(u"Example: 'flatpages_i18n/contact_page.html'. If this isn't \
         provided, the system will use 'flatpages_i18n/default.html'."))
     registration_required = models.BooleanField(
-        _(u'registration required'),
+        _(u'registration required'), default=False,
         help_text=_(u"If this is checked, only logged-in users will be able \
         to view the page."))
     weight = models.IntegerField(


### PR DESCRIPTION
Django 1.6 changed the default value of BooleanField from False to None. 
This patch avoids warnings in django master branche
