### PR TITLE
Python 3 compat as well as an issue in middleware

### DIFF
--- a/flatpages_i18n/admin.py
+++ b/flatpages_i18n/admin.py
@@ -6,9 +6,9 @@ from django.utils.translation import ugettext_lazy as _
 from modeltranslation.admin import TranslationAdmin
 from mptt.admin import MPTTModelAdmin
 
-from .forms import FlatpageForm, MenuItemForm
-from .models import FlatPage_i18n, MenuItem
-from .widgets import RedactorEditor
+from flatpages_i18n.forms import FlatpageForm, MenuItemForm
+from flatpages_i18n.models import FlatPage_i18n, MenuItem
+from flatpages_i18n.widgets import RedactorEditor
 
 
 class FlatPageAdmin(MPTTModelAdmin, TranslationAdmin):

--- a/flatpages_i18n/middleware.py
+++ b/flatpages_i18n/middleware.py
@@ -4,7 +4,14 @@ from django.http import Http404
 from flatpages_i18n.views import flatpage
 
 
-class FlatpageFallbackMiddleware(object):
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    # Works perfectly for everyone using MIDDLEWARE_CLASSES
+    MiddlewareMixin = object
+
+
+class FlatpageFallbackMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if response.status_code != 404:
             # No need to check for a flatpage for non-404 responses.

--- a/flatpages_i18n/urls.py
+++ b/flatpages_i18n/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
-from views import redactor_upload
-from forms import FileForm, ImageForm
+from flatpages_i18n.views import redactor_upload
+from flatpages_i18n.forms import FileForm, ImageForm
 
 urlpatterns = patterns('flatpages_i18n.views', (r'^(?P<url>.*)$', 'flatpage'),)
 

--- a/flatpages_i18n/views.py
+++ b/flatpages_i18n/views.py
@@ -10,8 +10,8 @@ from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_protect, csrf_exempt
 from django.views.decorators.http import require_POST
 
-from forms import ImageForm
-from models import FlatPage_i18n
+from flatpages_i18n.forms import ImageForm
+from flatpages_i18n.models import FlatPage_i18n
 
 
 DEFAULT_TEMPLATE = 'flatpages_i18n/default.html'


### PR DESCRIPTION
Hello again,

So, two things here. First is my last pull request for this same branch, about python 3 compatibility, was incomplete. I've fixed that.

The other one you can find in the middleware, which crashes with Django's new middleware system. Should not have any effect for any older Django versions, but alas I cannot say I've actually tested this on older versions.