### PR TITLE
Depreciation fix

### DIFF
--- a/flatpages_i18n/urls.py
+++ b/flatpages_i18n/urls.py
@@ -1,11 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from flatpages_i18n.views import redactor_upload
 from flatpages_i18n.forms import FileForm, ImageForm
 
-urlpatterns = patterns('flatpages_i18n.views', (r'^(?P<url>.*)$', 'flatpage'),)
-
-urlpatterns += patterns('',
+urlpatterns += (
     url('^upload/image/(?P<upload_to>.*)', redactor_upload, {
         'form_class': ImageForm,
         'response': lambda name, url: '<img src="%s" alt="%s" />' % (url, name),

--- a/flatpages_i18n/views.py
+++ b/flatpages_i18n/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import user_passes_test
 from django.core.files.storage import default_storage
 from django.http import Http404, HttpResponse, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404
-from django.template import loader, RequestContext
+from django.template import loader
 from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_protect, csrf_exempt
 from django.views.decorators.http import require_POST
@@ -85,11 +85,10 @@ def render_flatpage(request, f):
     f.title = mark_safe(f.title)
     f.content = mark_safe(f.content)
 
-    c = RequestContext(request, {
-        'flatpage': f,
-        'request': request
-    })
-    response = HttpResponse(t.render(c))
+    response = HttpResponse(t.render({
+        'flatpage': f
+    }, request))
+
     try:
         from django.core.xheaders import populate_xheaders
         populate_xheaders(request, response, FlatPage_i18n, f.id)


### PR DESCRIPTION
1.  django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

2. Fix  File "flatpages_i18n/views.py", line 96, in render_flatpage
    response = HttpResponse(t.render(c))
      raise TypeError('context must be a dict rather than %s.' % context.__class__.__name__)
TypeError: context must be a dict rather than RequestContext.

 

