### PR TITLE
Support for Django 2.0 with backwards compatibility

### DIFF
--- a/flatpages_i18n/forms.py
+++ b/flatpages_i18n/forms.py
@@ -20,9 +20,12 @@ class FlatpageForm(forms.ModelForm):
             raise forms.ValidationError(_(u"URL '%(url)s' is missing a leading slash.") % {'url': url})
 
         # check trailing slash
+        try:
+            middlewares = settings.MIDDLEWARE_CLASSES
+        except AttributeError:
+            middlewares = settings.MIDDLEWARE
         if settings.APPEND_SLASH and \
-            self.REQUIRED_MIDDLEWARE in settings.MIDDLEWARE_CLASSES and \
-                not url.endswith('/'):
+            self.REQUIRED_MIDDLEWARE in middlewares and not url.endswith('/'):
             raise forms.ValidationError(_(u"URL '%(url)s' is missing a trailing slash.") % {'url': url})
 
         # check URL uniqueness

--- a/flatpages_i18n/migrations/0001_initial.py
+++ b/flatpages_i18n/migrations/0001_initial.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('tree_id', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('level', models.PositiveIntegerField(editable=False, db_index=True)),
-                ('parent', mptt.fields.TreeForeignKey(related_name='children', blank=True, to='flatpages_i18n.FlatPage_i18n', null=True)),
+                ('parent', mptt.fields.TreeForeignKey(related_name='children', blank=True, to='flatpages_i18n.FlatPage_i18n', null=True, on_delete=django.db.models.deletion.SET_NULL)),
                 ('sites', models.ManyToManyField(to='sites.Site')),
             ],
             options={
@@ -70,8 +70,8 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('tree_id', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('level', models.PositiveIntegerField(editable=False, db_index=True)),
-                ('flatpage', models.ForeignKey(default=None, blank=True, to='flatpages_i18n.FlatPage_i18n', null=True, verbose_name='flatpage')),
-                ('parent', mptt.fields.TreeForeignKey(related_name='children', blank=True, to='flatpages_i18n.MenuItem', null=True)),
+                ('flatpage', models.ForeignKey(default=None, blank=True, to='flatpages_i18n.FlatPage_i18n', null=True, verbose_name='flatpage', on_delete=django.db.models.deletion.SET_NULL)),
+                ('parent', mptt.fields.TreeForeignKey(related_name='children', blank=True, to='flatpages_i18n.MenuItem', null=True, on_delete=django.db.models.deletion.SET_NULL)),
             ],
             options={
                 'ordering': ('weight', 'created'),

--- a/flatpages_i18n/migrations/0001_initial.py
+++ b/flatpages_i18n/migrations/0001_initial.py
@@ -12,13 +12,10 @@ def sync_fields(apps, schema_editor):
         'sync_translation_fields',
         verbosity=1,
         interactive=False,
-        run_syncdb=True,
     )
     call_command(
         'update_translation_fields',
         verbosity=1,
-        interactive=False,
-        run_syncdb=True,
     )
 
 

--- a/flatpages_i18n/models.py
+++ b/flatpages_i18n/models.py
@@ -12,7 +12,7 @@ class FlatPage_i18n(MPTTModel):
     WEIGHT = [(i, i) for i in range(-10, 10)]
 
     parent = TreeForeignKey('self', related_name='children',
-        null=True, blank=True)
+        null=True, blank=True, on_delete=models.SET_NULL)
     sites = models.ManyToManyField(Site)
     machine_name = models.CharField(_(u'machine name'), max_length=255,
         null=True, blank=True, default=None)
@@ -60,9 +60,9 @@ class MenuItem(MPTTModel):
     machine_name = models.CharField(_(u'machine name'), max_length=255,
         null=True, blank=True, default=None)
     parent = TreeForeignKey('self', related_name='children',
-        null=True, blank=True)
+        null=True, blank=True, on_delete=models.SET_NULL)
     flatpage = models.ForeignKey(FlatPage_i18n, verbose_name=_('flatpage'),
-        null=True, blank=True, default=None)
+        null=True, blank=True, default=None, on_delete=models.SET_NULL)
     custom_link = models.CharField(_(u'custom link'), max_length=255,
         null=True, blank=True, default=None)
     has_custom_link = models.BooleanField(_(u'has custom link'), default=False)

--- a/flatpages_i18n/templatetags/flatpages_i18n.py
+++ b/flatpages_i18n/templatetags/flatpages_i18n.py
@@ -157,7 +157,7 @@ def get_menu(context, key=None):
     }
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_flatpage_i18n(context, key=None):
     if key not in EMPTY_VALUES:
         try:

--- a/flatpages_i18n/templatetags/flatpages_i18n.py
+++ b/flatpages_i18n/templatetags/flatpages_i18n.py
@@ -157,7 +157,13 @@ def get_menu(context, key=None):
     }
 
 
-@register.simple_tag(takes_context=True)
+try:
+    assignment_tag = register.assignment_tag
+except AttributeError:
+    assignment_tag = register.simple_tag
+
+
+@assignment_tag(takes_context=True)
 def get_flatpage_i18n(context, key=None):
     if key not in EMPTY_VALUES:
         try:

--- a/flatpages_i18n/widgets.py
+++ b/flatpages_i18n/widgets.py
@@ -2,8 +2,11 @@ import json
 
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from django.urls import reverse
 from django.conf import settings
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 
 REDACTOR_OPTIONS = getattr(settings, 'FLATPAGES_REDACTOR_OPTIONS', {})

--- a/flatpages_i18n/widgets.py
+++ b/flatpages_i18n/widgets.py
@@ -2,7 +2,7 @@ import json
 
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 
 


### PR DESCRIPTION
This PR adds [support for Django 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/):
- [x] `on_delete` argument for ForeignKey and OneToOneField is now required
- [x] `assignment_tag` helper was removed, but `simple_tag` has this functionality [since Django 1.9](https://docs.djangoproject.com/en/2.0/releases/1.9/)
- [x] `django.core.urlresolvers` module was removed in favor of its new location, `django.urls`
- [x] Support for old-style middleware using `settings.MIDDLEWARE_CLASSES` was removed (`settings.MIDDLEWARE_CLASSES` was replaced with `settings.MIDDLEWARE`), `FlatpageForm` was updated to be able to use both
- [x] Remove unsupported options of `sync_translation_fields` and `update_translation_fields` commands